### PR TITLE
premature Genotyper class; compile unit functional under C++11

### DIFF
--- a/genotyper.cpp
+++ b/genotyper.cpp
@@ -1,0 +1,141 @@
+#include "genotyper.hpp"
+
+
+Genotyper::Genotyper(){
+    // according to RAII principle, the constructor should initialize the member variables
+    posterior_sv_genotype = {0.0, 0.0, 0.0, 0.0};
+}
+
+
+double Genotyper::prob_sfs_sv(int sfs_length, int sfs, allele a){
+
+    (void)(sfs_length); // suppress unused parameter warning
+
+    if (sfs == 1 && a == 1){
+        return 0.8;
+    }
+    else if (sfs == 0 && a == 0){
+        return 0.95;
+    }
+    else if (sfs == 0 && a == 1){
+        return 0.2;
+    }
+    else{ // sfs == 1 && a == 0
+        return 0.05;
+    }
+
+#ifdef DEBUG
+    assert(false); // should never reach here
+#endif
+
+    return -1;
+}
+
+
+double Genotyper::priorHap(int hap, int h){
+
+    if (h == 3){
+        return 0.5;
+    }
+
+    if (hap == h){
+        return 0.95;
+    }
+    else{
+        return 0.05;
+    }
+
+#ifdef DEBUG
+    assert(false); // should never reach here
+#endif
+
+    return -1;
+}
+
+
+double Genotyper::prior_genotype(variant v){
+
+    if (v == make_variant(0, 0)){
+        return 0.5;
+    }
+    else if (v == make_variant(0, 1) || v == make_variant(1, 0)){
+        return 0.22;
+    }
+    else{ // v == make_variant(1, 1)
+        return 0.06;
+    }
+
+#ifdef DEBUG
+    assert(false); // should never reach here
+#endif
+    
+    return -1;
+}
+
+
+double Genotyper::likelihood_read_give_gen_hap(int s, int hap, allele a){
+
+    (void)(hap); // suppress unused parameter warning
+
+    return this->prob_sfs_sv(20, s, a);
+}
+
+
+double Genotyper::likelihood_read_give_genotype(read r, variant v){
+
+    int hap1 = 1;
+    int hap2 = 2;
+
+    double read_likelihood_allel_0 = this->likelihood_read_give_gen_hap(std::get<0>(r), hap1, std::get<0>(v)) * this->priorHap(hap1, std::get<1>(r));
+    double read_likelihood_allel_1 = this->likelihood_read_give_gen_hap(std::get<0>(r), hap2, std::get<1>(v)) * this->priorHap(hap2, std::get<1>(r));
+
+    return read_likelihood_allel_0 + read_likelihood_allel_1;
+}
+
+
+double Genotyper::likelihood_allreads_give_genotype(std::vector<read> r_vec, variant v ){
+
+    double log_posterior_prob = 0.0;
+
+    for (auto r : r_vec){
+        log_posterior_prob += this->likelihood_read_give_genotype(r, v);
+    }
+
+    return log_posterior_prob;
+}
+
+
+/**
+ * @brief compute the posterior probability of each genotype given all reads
+ * 
+ * @param r_vec a vector of reads.
+ *        Each read is a tuple of two integers:
+ *        - the first integer is indication whether the read has a SFS supporting the variant allele (1) or not (0)
+ *        - the second integer is the predicted allele (haplo?)tag of the read (1 for haplotype 1, 2 for haplotype 2, 3 for NOTAG)    
+ * @return int 0 if success
+ */
+int Genotyper::posterior_sv_genotype_give_reads(std::vector<read> r_vec){
+
+    int i=0;
+    int total = 0;
+
+    std::vector<std::tuple<int,int> > g = {std::make_tuple(0, 0), std::make_tuple(0, 1), std::make_tuple(1, 0), std::make_tuple(1, 1)};
+
+    for (auto v : g){
+        this->posterior_sv_genotype[i] = this->likelihood_allreads_give_genotype(r_vec, v) + log(this->prior_genotype(v));
+        total += exp(this->posterior_sv_genotype[i]);
+        i++;
+    }
+
+    for (i=0; i<4; i++){
+        this->posterior_sv_genotype[i] = exp(this->posterior_sv_genotype[i]) / total;
+    }
+
+    return 0;
+}
+
+
+std::vector<double> Genotyper::get_posterior_sv_genotype(){
+
+    return this->posterior_sv_genotype;
+}

--- a/genotyper.hpp
+++ b/genotyper.hpp
@@ -1,0 +1,58 @@
+#ifndef GENOTYPER_HPP
+#define GENOTYPER_HPP
+
+#include <string>
+#include <tuple>
+#include <functional>
+#include <vector>
+#include <cmath>
+
+
+typedef std::tuple<int, int> variant;
+typedef std::tuple<int, int> read;
+typedef int allele;
+
+static variant make_variant(int a, int b){return std::make_tuple(a, b);}
+static read make_read(int a, int b){return std::make_tuple(a, b);}
+
+// Define a class "Genotyper" that will be used to compute the genotype of Structural Variants
+// the class has the following private member functions:
+// 1. prob_sfs_sv: compute the likelihood to observe a read based on it has a SFS and given the genotype of the SV that read spans
+// 2. priorHap: compute the prior probability to observe a read based on its predicted haplotype
+// 3. prior_genotype: define prior probability of each genotype
+// 4. likelihood_read_give_gen_hap
+// 5. likelihood_allreads_give_genotype: log likelihood of all reads
+// this class has the following public member functions:
+// 1. posterier_sv_genotype_give_reads: compute the posterior probability of each genotype given all reads
+// 2. get_posterior_sv_genotype: compute the posterior probability of each genotype
+// this class has the following private member variables:
+// 1. vector of posterior probability of each genotype
+class Genotyper{
+private:
+    //
+    double prob_sfs_sv(int sfs_length, int sfs, allele a);
+    // 
+    double priorHap(int hap, int h);
+    // 
+    double prior_genotype(variant v);
+    //
+    double likelihood_read_give_gen_hap(int s, int hap, allele a);
+    // 
+    double likelihood_read_give_genotype(read r, variant v);
+    //
+    double likelihood_allreads_give_genotype(std::vector<read> r_vec, variant v );
+
+public:
+    Genotyper();
+    //
+    int posterior_sv_genotype_give_reads(std::vector<read> r_vec);
+    //
+    std::vector<double> get_posterior_sv_genotype();
+
+private:
+    std::vector<double> posterior_sv_genotype;
+};
+
+
+
+#endif // GENOTYPER_HPP


### PR DESCRIPTION
Hey @ldenti , 

here is a straightforward translation of the genotyping functionality, plus some mild error checking. Not the prettiest or most performance optimized code  yet but it should do as a first version. I compiled it successfully under Linux using 
```
g++ -std=c++11 genotyper.cpp
```
In order to use the Genotyper class with your _WIP_ implementation of the container class under _SV.cpp_ you might want to add a list of "reads" spanning the potential SV as a member of the SV class in the format of:
```
std::vector<std:tuple<int,int> > my_vec_of_reads;
```
s.t. _my_vec_of_reads_ is a C++ vector of tuples where each "read" in that vector is a tuple with index 0 being the indication whether the read has a SFS supporting the variant or not and index 1 being the predicted haplotype of that read. More details in the doxygen header of the _posterior_sv_genotype_give_reads()_ function within _genotyper.cpp_.